### PR TITLE
feat: apply direct edits to active editor and show colored diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "accessible-agent",
       "version": "0.0.1",
+      "dependencies": {
+        "diff": "^5.2.0"
+      },
       "devDependencies": {
+        "@types/diff": "^7.0.0",
         "@types/node": "^20.11.30",
         "@types/vscode": "1.90.0",
         "typescript": "^5.4.5",
@@ -16,6 +20,13 @@
       "engines": {
         "vscode": "^1.90.0"
       }
+    },
+    "node_modules/@types/diff": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
+      "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.10",
@@ -33,6 +44,15 @@
       "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,12 @@
     "watch": "tsc -watch -p ./",
     "lint": "echo \"No lint configured\""
   },
+  "dependencies": {
+    "diff": "^5.2.0"
+  },
   "devDependencies": {
     "@types/node": "^20.11.30",
+    "@types/diff": "^7.0.0",
     "@types/vscode": "1.90.0",
     "typescript": "^5.4.5",
     "undici": "^6.19.8"


### PR DESCRIPTION
- Add API-driven model list and model picker\n- Remove artificial token cap; set max_tokens to 4000 per API\n- Parse model response, apply updated file to active editor\n- Render colored unified diff in sidebar and open VS Code diff view\n- Proceed on non-UI files; improve error handling and UX\n- Increase output height; add types for 'diff'