### PR TITLE
feat(rules): presets and custom rules; include in prompts

### DIFF
--- a/src/rules/android.ts
+++ b/src/rules/android.ts
@@ -1,0 +1,11 @@
+export const ANDROID_RULES = `
+Predefined accessibility rules for Android:
+1) Every clickable element must have an appropriate role (e.g., Button) and be reachable via TalkBack.
+2) Every title or screen header should be announced as a heading.
+3) Provide meaningful contentDescription for non-decorative images and actionable icons.
+4) For Compose: use Semantics, roles, and contentDescription; ensure minimum touch target sizes.
+5) For XML: use importantForAccessibility, focusable, labelFor where applicable; mark decorative images as not important for accessibility.
+6) Do not reference strings from a resource file in the output; use the literal string needed for contentDescription/labels in the updated code sample.
+7) Maintain existing behavior; do not change logic beyond adding accessibility improvements.`;
+
+

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,20 @@
+import { ANDROID_RULES } from './android';
+import { IOS_RULES } from './ios';
+import { WEB_RULES } from './web';
+
+export type RulesPreset = 'android' | 'ios' | 'web' | 'custom' | '';
+
+export function getPresetRules(preset: RulesPreset): string {
+  switch (preset) {
+    case 'android':
+      return ANDROID_RULES;
+    case 'ios':
+      return IOS_RULES;
+    case 'web':
+      return WEB_RULES;
+    default:
+      return '';
+  }
+}
+
+

--- a/src/rules/ios.ts
+++ b/src/rules/ios.ts
@@ -1,0 +1,10 @@
+export const IOS_RULES = `
+Predefined accessibility rules for iOS:
+1) Use accessibilityLabel and accessibilityHint for controls and images.
+2) Mark headings and important landmarks for VoiceOver ordering.
+3) Ensure controls have sufficient touch targets and are reachable in a logical focus order.
+4) Group related elements appropriately; use traits for buttons, headers, and images.
+5) Provide literal labels/hints in code rather than referencing external resource files.
+6) Maintain existing logic and layout; only add accessibility attributes.`;
+
+

--- a/src/rules/web.ts
+++ b/src/rules/web.ts
@@ -1,0 +1,11 @@
+export const WEB_RULES = `
+Predefined accessibility rules for Web:
+1) Prefer semantic HTML elements; only use ARIA when semantics are missing.
+2) All interactive elements must be keyboard accessible and have visible focus.
+3) Headings must follow a logical structure; titles should announce as headings.
+4) Images require meaningful alt text unless purely decorative (then use empty alt or aria-hidden).
+5) Associate labels with form controls using <label for> or aria-label/aria-labelledby.
+6) Manage focus on dialogs and dynamic content updates.
+7) Provide literal strings for labels/alt in the example output; do not reference external resource files.`;
+
+


### PR DESCRIPTION
- UI: add Rules preset dropdown (Android/iOS/Web) and rules textarea; auto-fill on preset select\n- Persistence: save preset/text; restore in view state; hydrate on load\n- Prompts: inject extraRules into single-shot and chunked flows\n- Refactor: move predefined rules to src/rules/*.ts